### PR TITLE
Remove hack archive link from mobile view

### DIFF
--- a/src/components/GirlsHooHack2022/Footer/Footer.tsx
+++ b/src/components/GirlsHooHack2022/Footer/Footer.tsx
@@ -55,13 +55,15 @@ function Footer() {
           <a href="mailto:girlshoohack@gmail.com" className="mono text-white interactive">girlshoohack@gmail.com</a>
           </Row>
         </Col>
-        <Col className="text-white" style={{marginLeft:50}}> 
-          <Row>
-            GHH 2021 Website: 
-          </Row>
-          <Row>
-            <a href="/hack2021" target="_blank" rel="noreferrer noopener" className="mono text-white interactive pr-5 pr-2">hack2021</a>
-          </Row>
+        <Col className="text-white" style={{marginLeft:35}}> 
+          {!isMobile && <Col className="text-white" style={{marginLeft:35}}>
+            <Row>
+              GHH 2021 Website: 
+            </Row>
+            <Row>
+              <a href="/hack2021" target="_blank" rel="noreferrer noopener" className="mono text-white interactive pr-5 pr-2">hack2021</a>
+            </Row>
+          </Col>}
         </Col>
       </Row>
       <Row className = {`${isMobile ? "footerMLHCodeMobile" : "footerMLHCodeDesktop"} position-absolute`}>


### PR DESCRIPTION
Removed the 2021 hack archive link from the mobile view of GHH 2022 (for formatting and space)
<img width="1421" alt="GHHdesktop" src="https://user-images.githubusercontent.com/92696948/180494974-ea7f1b56-6ccc-4f09-82e5-50335934e625.png">
<img width="947" alt="GHHmobile" src="https://user-images.githubusercontent.com/92696948/180494994-07ed9d79-d23e-4c8b-aea3-099d2e310df3.png">

