### PR TITLE
GHH mobile navbar (updated)

### DIFF
--- a/src/assets/images/hamburgericon.svg
+++ b/src/assets/images/hamburgericon.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 80 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="55" height="10" fill="white"></rect>
+    <rect y="20" width="55" height="10" fill="white"></rect>
+    <rect y="40" width="55" height="10" fill="white"></rect>
+</svg>

--- a/src/components/GirlsHooHack2022/GirlsHooHack.tsx
+++ b/src/components/GirlsHooHack2022/GirlsHooHack.tsx
@@ -1,5 +1,6 @@
 import Header from './Header/Header';
 import NavbarGHH from './NavbarGHH/NavbarGHH';
+import MobileNavbarGHH from './NavbarGHH/MobileNavbarGHHs';
 import MobileHeader from './Header/MobileHeader';
 import About from './About/About';
 import JumpStart from './JumpStart/JumpStart';
@@ -23,6 +24,7 @@ function GirlsHooHack() {
         <Header id="Header"/>
       </BrowserView>
       <MobileView>
+        <MobileNavbarGHH />
         <MobileHeader id="MobileHeader"/>
         <img src={Waves} style={{marginTop:"-215px", marginBottom:"-120px"}} width = "100%" alt="Orange wave" />
       </MobileView>

--- a/src/components/GirlsHooHack2022/Header/MobileHeader.tsx
+++ b/src/components/GirlsHooHack2022/Header/MobileHeader.tsx
@@ -2,7 +2,6 @@ import {Row} from 'react-bootstrap';
 import {Col} from 'react-bootstrap';
 import SignUpCircle from '../../../assets/images/sign-up-hack-circle.svg';
 import SignUpMobile from '../../../assets/images/sign-up-mobile.svg';
-import SignupBanner from '../../../assets/images/signup-banner.png';
 
 
 interface Props {
@@ -14,16 +13,6 @@ function MobileHeader(props: Props) {
     return(
         <div id={props.id} className="container-fluid bg-turq">
             <meta id="viewport" name="viewport" content="width=320; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;"></meta>
-            <Row>
-                <Col xs={12}>
-                <a href="https://mlh.io/na?utm_source=na-hackathon&utm_medium=TrustBadge&utm_campaign=2023-season&utm_content=white" target="_blank" rel="noreferrer noopener">
-                    <img className="MLHBANNER pr-2" src="https://s3.amazonaws.com/logged-assets/trust-badge/2023/mlh-trust-badge-2023-white.svg" alt="Major League Hacking 2023 Hackathon Season" width="85" height="152"/> 
-                </a>
-                <a className="pr-5" href="https://girls-hoo-hack-2021.devpost.com/" target="_blank" rel="noreferrer noopener">
-                    <img className="mobilesignupbanner float-right" src={SignupBanner} alt="Signup banner" width="50" height="100"/>
-                </a>
-                </Col>
-            </Row>
 
             <Row className="mono text-blue pt-5 pl-4 pb-n5" style={{fontSize:13.5}}>
                 <text><big>2022 Hybrid Hackathon</big></text>

--- a/src/components/GirlsHooHack2022/NavbarGHH/MobileNavContents.tsx
+++ b/src/components/GirlsHooHack2022/NavbarGHH/MobileNavContents.tsx
@@ -1,0 +1,56 @@
+import { Row } from 'react-bootstrap';
+import email from '../../../assets/images/envelope-solid.svg';
+import instagram from '../../../assets/images/instagram-square-brands.svg';
+import discord from '../../../assets/images/discord-brands.svg';
+import facebook from '../../../assets/images/facebook-f-brands.svg';
+import twitter from '../../../assets/images/twitter-brands.svg';
+
+interface Props {
+  toggle? : () => void;
+  circle? : boolean;
+}
+
+function MobileNavContents(props: Props) {
+
+  return (
+    <div>
+      <div className="mobilelinks">
+        <Row className="pb-5">
+          <a href="#About" onClick={props.toggle} className="mono text-white interactive pr-5 pr-2" style={{fontSize: 35, fontWeight: 'bold'}}>About</a>
+        </Row>
+        <Row className="pb-5">
+          <a href="#Jumpstart" onClick={props.toggle}  className="mono text-white interactive pr-5 pr-2" style={{fontSize: 35, fontWeight: 'bold'}}>Jumpstart</a>
+        </Row>
+        <Row className="pb-5">
+          <a href="#Schedule" onClick={props.toggle} className="mono text-white interactive pr-5 pr-2" style={{fontSize: 35, fontWeight: 'bold'}}>Schedule</a>
+        </Row>
+        <Row className="pb-5">
+          <a href="#FAQ" onClick={props.toggle} className="mono text-white interactive pr-5 pr-2" style={{fontSize: 35, fontWeight: 'bold'}}>FAQ</a>
+        </Row>
+        <Row>
+          <a href="#Sponsors" onClick={props.toggle} className="mono text-white interactive pr-5 pr-2" style={{fontSize: 35, fontWeight: 'bold'}}>Sponsors</a>
+        </Row>
+      </div>
+
+      <div className="mobilenavfooter pt-4">
+        <a href="mailto:girlshoohack@gmail.com" className="mono text-white interactive pl-3" target="_blank" rel="noreferrer noopener" onClick={props.toggle}>
+          <img src={email} width="28px" alt="Email icon"/>
+        </a>
+        <a href="https://www.instagram.com/girlshoohack/" target="_blank" rel="noreferrer noopener" onClick={props.toggle}>
+          <img src={instagram} width="28px" alt="Instagram logo" className="ml-4"/>
+        </a>
+        <a href="https://discord.gg/bFX5nTAxVz" target="_blank" rel="noreferrer noopener" onClick={props.toggle}>
+          <img src={discord} width="28px" alt="Discord logo" className="ml-4"/>
+        </a>
+        <a href="https://www.facebook.com/gwcuva/" target="_blank" rel="noreferrer noopener" onClick={props.toggle}>
+          <img src={facebook} width="20px" alt="Facebook logo" className="ml-4"/>
+        </a>
+        <a href="https://twitter.com/gwcuva" target="_blank" rel="noreferrer noopener" onClick={props.toggle}>
+          <img src={twitter} width="28px" alt="Twitter logo" className="ml-4"/>
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default MobileNavContents;

--- a/src/components/GirlsHooHack2022/NavbarGHH/MobileNavbarGHHs.tsx
+++ b/src/components/GirlsHooHack2022/NavbarGHH/MobileNavbarGHHs.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import Logo from '../../../assets/images/peacock-logo.svg';
+import ReactModal from 'react-modal';
+import { Col, Row } from 'react-bootstrap';
+import { X } from 'react-feather';
+import MobileNavContents from './MobileNavContents'
+import SignupBanner from '../../../assets/images/signup-banner.png';
+import HamburgerIcon from '../../../assets/images/hamburgericon.svg';
+
+function MobileNavbarGHHs() {
+
+    const [menuOpen, setMenuOpen] = useState(false);
+  
+    function toggleModal() {
+      setMenuOpen(!menuOpen)
+    }
+    return (
+    <nav className="bg-turq d-flex justify-content-between align-items-center">
+      <img src={Logo} width="112px" height="44px" alt="Girls Who Code at the University of Virginia logo" className={menuOpen ? "hidden" : "pl-3"}/>
+
+      <Row>
+        <Col xs={16}>
+          <button className= {`pr-2 button-unstyled ${menuOpen && "hidden"}`} onClick={() => toggleModal()}>
+            <img className="mobilehamburgericon" src={HamburgerIcon} alt="HamburgerIcon" width="50" height="70"/>
+          </button>
+          
+          <a className="pr-5" href="https://girls-hoo-hack-2021.devpost.com/" target="_blank" rel="noreferrer noopener">
+              <img className="mobilesignupbanner" src={SignupBanner} alt="Signup banner" width="55" height="110"/>
+          </a>
+        </Col>
+      </Row>
+
+      <ReactModal 
+        appElement={document.getElementById('root') as HTMLElement}
+        isOpen={menuOpen} 
+        className="bg-turq full-screen" 
+        contentLabel="Menu">
+        <Col>
+          <Row className="align-items-center">
+            <Col>
+              <img src={Logo} width="112px" height="44px" alt="Girls Who Code at the University of Virginia logo" className="back"/>
+            </Col>
+            <Col xs={2.5}>
+              <button className="mono text-white button-unstyled pr-2" onClick={() => toggleModal()}><X color="white" size={40}/></button>
+            </Col>
+            <Col xs={3}>
+              <a className="pr-5" href="https://girls-hoo-hack-2021.devpost.com/" target="_blank" rel="noreferrer noopener">
+                  <img className="mobilesignupbanner" src={SignupBanner} alt="Signup banner" width="55" height="110"/>
+              </a>
+            </Col>
+          </Row>
+          <MobileNavContents toggle={() => toggleModal()} />
+        </Col>
+      </ReactModal>
+    </nav>
+    );
+}
+
+export default MobileNavbarGHHs;

--- a/src/index.scss
+++ b/src/index.scss
@@ -332,3 +332,17 @@ p.hack {
 .ghhlogo {
   margin-left: 30px;
 }
+
+.mobilelinks{
+  padding-left: 20px;
+  padding-top: 60px;
+}
+
+.mobilenavfooter{
+  height: 85px;
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  background-color:#003046;
+}


### PR DESCRIPTION
Added a mobile navbar to the GHH2022 website (fixed previous merge conflicts from Mobile Navbar#185)
<img width="1423" alt="GHHDesktop" src="https://user-images.githubusercontent.com/92696948/180500116-9282fdbd-8338-4065-bce4-ffaea03f75d4.png">
<img width="950" alt="GHHMobile" src="https://user-images.githubusercontent.com/92696948/180500145-6a054239-c15c-4393-ba74-286f60da89a6.png">
<img width="932" alt="GHHMobileNav" src="https://user-images.githubusercontent.com/92696948/180500152-0bdaa49b-231e-4e75-813a-652d029dd3ee.png">

